### PR TITLE
Simplified Content parsing and made mimeType optional

### DIFF
--- a/harpy/content.py
+++ b/harpy/content.py
@@ -1,22 +1,10 @@
 class Content(object):
-    def __init__(self, j):
-        self.raw = j
+
+    def __init__(self, raw):
+        self.raw = raw
 
         self.size = self.raw["size"]
-        if "compression" in self.raw:
-            self.compression = self.raw["compression"]
-        else:
-            self.compression = ''
-        self.mime_type = self.raw["mimeType"]
-        if "text" in self.raw:
-            self.text = self.raw["text"]
-        else:
-            self.text = ''
-        if "encoding" in self.raw:
-            self.encoding = self.raw["encoding"]
-        else:
-            self.encoding = ''
-        if "comment" in self.raw:
-            self.comment = self.raw["comment"]
-        else:
-            self.comment = ''
+
+        for field in ["compression", "mimeType", "text",
+                      "encoding", "comment"]:
+            setattr(self, field, self.raw.get(field, ""))


### PR DESCRIPTION
Some dumps from chrome with content don't contain mimeType,
so I made mimeType optional like the other fields were already.
